### PR TITLE
fix: remove ingress default conf (form is append only)

### DIFF
--- a/challenges/infra/kubrac/challenge.yaml
+++ b/challenges/infra/kubrac/challenge.yaml
@@ -44,8 +44,3 @@ spec:
     kind: sdk.ctfer.io/manual
     spec:
       directory: infra/scenario
-    additional:
-      # override default settings (used for Nginx local tests)
-      ingressAnnotations: nil
-      ingressNamespace: nil
-      ingressLabels: nil

--- a/challenges/infra/kubrac/infra/scenario/main.go
+++ b/challenges/infra/kubrac/infra/scenario/main.go
@@ -457,19 +457,6 @@ func loadConfig(additionals map[string]string) (*Config, error) {
 	conf := &Config{
 		Hostname: "24hiut25.ctfer.io",
 		Image:    "infra/kubrac:v0.1.0",
-		Registry: "", // keep empty
-		// The following fits for a Nginx-based use case, which is the local setup
-		IngressAnnotations: map[string]string{
-			"kubernetes.io/ingress.class":                  "nginx",
-			"nginx.ingress.kubernetes.io/backend-protocol": "HTTP",
-			"nginx.ingress.kubernetes.io/ssl-redirect":     "true",
-			"nginx.ingress.kubernetes.io/proxy-body-size":  "50m",
-		},
-		IngressNamespace: "ingress-nginx",
-		IngressLabels: map[string]string{
-			"app.kubernetes.io/component": "controller",
-			"app.kubernetes.io/instance":  "ingress-nginx",
-		},
 	}
 
 	// Override with additionals

--- a/challenges/pentest/beverage-bazaar/challenge.yaml
+++ b/challenges/pentest/beverage-bazaar/challenge.yaml
@@ -46,8 +46,3 @@ spec:
     kind: sdk.ctfer.io/manual
     spec:
       directory: infra/scenario
-    additional:
-      # override default settings (used for Nginx local tests)
-      ingressAnnotations: nil
-      ingressNamespace: nil
-      ingressLabels: nil

--- a/challenges/pentest/beverage-bazaar/infra/scenario/main.go
+++ b/challenges/pentest/beverage-bazaar/infra/scenario/main.go
@@ -202,7 +202,6 @@ func loadConfig(additionals map[string]string) (*Config, error) {
 	conf := &Config{
 		Hostname:       "24hiut25.ctfer.io",
 		Image:          "pentest/beverage-bazaar:v0.1.0",
-		Registry:       "", // keep empty
 		ConnectionInfo: "challenges.24hiut25.ctfer.io",
 	}
 

--- a/challenges/pwn/ret2popacola/challenge.yaml
+++ b/challenges/pwn/ret2popacola/challenge.yaml
@@ -59,7 +59,3 @@ spec:
           {{- $port = index $parts 1 -}}
         {{- end -}}
         nc {{ $host }} {{ $port }}
-      # override default settings (used for Nginx local tests)
-      ingressAnnotations: nil
-      ingressNamespace: nil
-      ingressLabels: nil

--- a/challenges/pwn/ret2popacola/infra/scenario/main.go
+++ b/challenges/pwn/ret2popacola/infra/scenario/main.go
@@ -101,19 +101,6 @@ func loadConfig(additionals map[string]string) (*Config, error) {
 	conf := &Config{
 		Hostname: "24hiut25.ctfer.io",
 		Image:    "pwn/ret2popacola:v0.1.0",
-		Registry: "", // keep empty
-		// The following fits for a Nginx-based use case, which is the local setup
-		IngressAnnotations: map[string]string{
-			"kubernetes.io/ingress.class":                  "nginx",
-			"nginx.ingress.kubernetes.io/backend-protocol": "HTTP",
-			"nginx.ingress.kubernetes.io/ssl-redirect":     "true",
-			"nginx.ingress.kubernetes.io/proxy-body-size":  "50m",
-		},
-		IngressNamespace: "ingress-nginx",
-		IngressLabels: map[string]string{
-			"app.kubernetes.io/component": "controller",
-			"app.kubernetes.io/instance":  "ingress-nginx",
-		},
 	}
 
 	// Override with additionals

--- a/challenges/web/Intern-Work/challenge.yaml
+++ b/challenges/web/Intern-Work/challenge.yaml
@@ -39,8 +39,3 @@ spec:
     kind: sdk.ctfer.io/manual
     spec:
       directory: infra/scenario
-    additional:
-      # override default settings (used for Nginx local tests)
-      ingressAnnotations: nil
-      ingressNamespace: nil
-      ingressLabels: nil

--- a/challenges/web/Intern-Work/infra/scenario/main.go
+++ b/challenges/web/Intern-Work/infra/scenario/main.go
@@ -75,19 +75,6 @@ func loadConfig(additionals map[string]string) (*Config, error) {
 	conf := &Config{
 		Hostname: "24hiut25.ctfer.io",
 		Image:    "web/intern-work:v0.1.0",
-		Registry: "", // keep empty
-		// The following fits for a Nginx-based use case, which is the local setup
-		IngressAnnotations: map[string]string{
-			"kubernetes.io/ingress.class":                  "nginx",
-			"nginx.ingress.kubernetes.io/backend-protocol": "HTTP",
-			"nginx.ingress.kubernetes.io/ssl-redirect":     "true",
-			"nginx.ingress.kubernetes.io/proxy-body-size":  "50m",
-		},
-		IngressNamespace: "ingress-nginx",
-		IngressLabels: map[string]string{
-			"app.kubernetes.io/component": "controller",
-			"app.kubernetes.io/instance":  "ingress-nginx",
-		},
 	}
 
 	// Override with additionals

--- a/challenges/web/blog_cola_1_2/challenge.yaml
+++ b/challenges/web/blog_cola_1_2/challenge.yaml
@@ -39,8 +39,3 @@ spec:
     kind: sdk.ctfer.io/manual
     spec:
       directory: infra/scenario
-    additional:
-      # override default settings (used for Nginx local tests)
-      ingressAnnotations: nil
-      ingressNamespace: nil
-      ingressLabels: nil

--- a/challenges/web/blog_cola_1_2/infra/scenario/main.go
+++ b/challenges/web/blog_cola_1_2/infra/scenario/main.go
@@ -73,19 +73,6 @@ func loadConfig(additionals map[string]string) (*Config, error) {
 	conf := &Config{
 		Hostname: "24hiut25.ctfer.io",
 		Image:    "web/blob-cola-1:v0.1.0",
-		Registry: "", // keep empty
-		// The following fits for a Nginx-based use case, which is the local setup
-		IngressAnnotations: map[string]string{
-			"kubernetes.io/ingress.class":                  "nginx",
-			"nginx.ingress.kubernetes.io/backend-protocol": "HTTP",
-			"nginx.ingress.kubernetes.io/ssl-redirect":     "true",
-			"nginx.ingress.kubernetes.io/proxy-body-size":  "50m",
-		},
-		IngressNamespace: "ingress-nginx",
-		IngressLabels: map[string]string{
-			"app.kubernetes.io/component": "controller",
-			"app.kubernetes.io/instance":  "ingress-nginx",
-		},
 	}
 
 	// Override with additionals

--- a/challenges/web/blog_cola_2_2/challenge.yaml
+++ b/challenges/web/blog_cola_2_2/challenge.yaml
@@ -43,8 +43,3 @@ spec:
     kind: sdk.ctfer.io/manual
     spec:
       directory: infra/scenario
-    additional:
-      # override default settings (used for Nginx local tests)
-      ingressAnnotations: nil
-      ingressNamespace: nil
-      ingressLabels: nil

--- a/challenges/web/blog_cola_2_2/infra/scenario/main.go
+++ b/challenges/web/blog_cola_2_2/infra/scenario/main.go
@@ -73,19 +73,6 @@ func loadConfig(additionals map[string]string) (*Config, error) {
 	conf := &Config{
 		Hostname: "24hiut25.ctfer.io",
 		Image:    "web/blob-cola-2:v0.1.0",
-		Registry: "", // keep empty
-		// The following fits for a Nginx-based use case, which is the local setup
-		IngressAnnotations: map[string]string{
-			"kubernetes.io/ingress.class":                  "nginx",
-			"nginx.ingress.kubernetes.io/backend-protocol": "HTTP",
-			"nginx.ingress.kubernetes.io/ssl-redirect":     "true",
-			"nginx.ingress.kubernetes.io/proxy-body-size":  "50m",
-		},
-		IngressNamespace: "ingress-nginx",
-		IngressLabels: map[string]string{
-			"app.kubernetes.io/component": "controller",
-			"app.kubernetes.io/instance":  "ingress-nginx",
-		},
 	}
 
 	// Override with additionals

--- a/challenges/web/sticky-match/challenge.yaml
+++ b/challenges/web/sticky-match/challenge.yaml
@@ -39,8 +39,3 @@ spec:
     kind: sdk.ctfer.io/manual
     spec:
       directory: infra/scenario
-    additional:
-      # override default settings (used for Nginx local tests)
-      ingressAnnotations: nil
-      ingressNamespace: nil
-      ingressLabels: nil

--- a/challenges/web/sticky-match/infra/scenario/main.go
+++ b/challenges/web/sticky-match/infra/scenario/main.go
@@ -62,19 +62,6 @@ func loadConfig(additionals map[string]string) (*Config, error) {
 	conf := &Config{
 		Hostname: "24hiut25.ctfer.io",
 		Image:    "web/sticky-match:v0.1.0",
-		Registry: "", // keep empty
-		// The following fits for a Nginx-based use case, which is the local setup
-		IngressAnnotations: map[string]string{
-			"kubernetes.io/ingress.class":                  "nginx",
-			"nginx.ingress.kubernetes.io/backend-protocol": "HTTP",
-			"nginx.ingress.kubernetes.io/ssl-redirect":     "true",
-			"nginx.ingress.kubernetes.io/proxy-body-size":  "50m",
-		},
-		IngressNamespace: "ingress-nginx",
-		IngressLabels: map[string]string{
-			"app.kubernetes.io/component": "controller",
-			"app.kubernetes.io/instance":  "ingress-nginx",
-		},
 	}
 
 	// Override with additionals

--- a/challenges/web/wordpressure/challenge.yaml
+++ b/challenges/web/wordpressure/challenge.yaml
@@ -46,8 +46,3 @@ spec:
     kind: sdk.ctfer.io/manual
     spec:
       directory: infra/scenario
-    additional:
-      # override default settings (used for Nginx local tests)
-      ingressAnnotations: nil
-      ingressNamespace: nil
-      ingressLabels: nil

--- a/challenges/web/wordpressure/infra/scenario/main.go
+++ b/challenges/web/wordpressure/infra/scenario/main.go
@@ -503,19 +503,6 @@ func loadConfig(additionals map[string]string) (*Config, error) {
 		ImageWordpress:    "library/wordpress:php8.2-apache",
 		ImageWordpressCLI: "web/wordpressure-cli:v0.1.0",
 		ImageMySQL:        "library/mysql:9.2.0",
-		Registry:          "", // keep empty
-		// The following fits for a Nginx-based use case, which is the local setup
-		IngressAnnotations: map[string]string{
-			"kubernetes.io/ingress.class":                  "nginx",
-			"nginx.ingress.kubernetes.io/backend-protocol": "HTTP",
-			"nginx.ingress.kubernetes.io/ssl-redirect":     "true",
-			"nginx.ingress.kubernetes.io/proxy-body-size":  "50m",
-		},
-		IngressNamespace: "ingress-nginx",
-		IngressLabels: map[string]string{
-			"app.kubernetes.io/component": "controller",
-			"app.kubernetes.io/instance":  "ingress-nginx",
-		},
 	}
 
 	// Override with additionals


### PR DESCRIPTION
This PR removes the default ingress configuration for Nginx, as we observe the form/v4 behavior is to append to the map rather than erasing it (makes sense). Further changes will come after the event to make sure ease of reproducibility without the whole infrastructure, especially locally.