### PR TITLE
fix: move connection info from additionals

### DIFF
--- a/challenges/pentest/fatal-request/challenge.yaml
+++ b/challenges/pentest/fatal-request/challenge.yaml
@@ -55,14 +55,3 @@ spec:
     kind: sdk.ctfer.io/manual
     spec:
       directory: infra/scenario
-    additional:
-      # Keep connection info in additional (will be easier to migrate to a recipe later)
-      connectionInfo: |
-        {{- $hostport := index .Ports "8080/TCP" -}}
-        {{- $parts := splitList ":" $hostport -}}
-        {{- $host := index $parts 0 -}}
-        {{- $port := "" -}}
-        {{- if gt (len $parts) 1 -}}
-          {{- $port = index $parts 1 -}}
-        {{- end -}}
-        ssh -p {{ $port }} {{ $host }}

--- a/challenges/pentest/fatal-request/infra/scenario/main.go
+++ b/challenges/pentest/fatal-request/infra/scenario/main.go
@@ -95,6 +95,14 @@ func loadConfig(additionals map[string]string) (*Config, error) {
 		Hostname: "24hiut25.ctfer.io",
 		Image:    "pentest/fatal-request:v0.1.0",
 		Registry: "", // keep empty
+		ConnectionInfo: `{{- $hostport := index .Ports "8080/TCP" -}}
+{{- $parts := splitList ":" $hostport -}}
+{{- $host := index $parts 0 -}}
+{{- $port := "" -}}
+{{- if gt (len $parts) 1 -}}
+	{{- $port = index $parts 1 -}}
+{{- end -}}
+ssh -p {{ $port }} {{ $host }}`,
 	}
 
 	// Override with additionals

--- a/challenges/pentest/illusionniste/challenge.yaml
+++ b/challenges/pentest/illusionniste/challenge.yaml
@@ -47,14 +47,3 @@ spec:
     kind: sdk.ctfer.io/manual
     spec:
       directory: infra/scenario
-    additional:
-      # Keep connection info in additional (will be easier to migrate to a recipe later)
-      connectionInfo: |
-        {{- $hostport := index .Ports "22/TCP" -}}
-        {{- $parts := splitList ":" $hostport -}}
-        {{- $host := index $parts 0 -}}
-        {{- $port := "" -}}
-        {{- if gt (len $parts) 1 -}}
-          {{- $port = index $parts 1 -}}
-        {{- end -}}
-        ssh -p {{ $port }} {{ $host }} user:password

--- a/challenges/pentest/illusionniste/infra/scenario/main.go
+++ b/challenges/pentest/illusionniste/infra/scenario/main.go
@@ -95,6 +95,14 @@ func loadConfig(additionals map[string]string) (*Config, error) {
 		Hostname: "24hiut25.ctfer.io",
 		Image:    "pentest/illusioniste:v0.1.0",
 		Registry: "", // keep empty
+		ConnectionInfo: `{{- $hostport := index .Ports "22/TCP" -}}
+{{- $parts := splitList ":" $hostport -}}
+{{- $host := index $parts 0 -}}
+{{- $port := "" -}}
+{{- if gt (len $parts) 1 -}}
+	{{- $port = index $parts 1 -}}
+{{- end -}}
+ssh -p {{ $port }} {{ $host }} user:password`,
 	}
 
 	// Override with additionals

--- a/challenges/pwn/ret2popacola/challenge.yaml
+++ b/challenges/pwn/ret2popacola/challenge.yaml
@@ -48,14 +48,3 @@ spec:
     kind: sdk.ctfer.io/manual
     spec:
       directory: infra/scenario
-    additional:
-      # Keep connection info in additional (will be easier to migrate to a recipe later)
-      connectionInfo: |
-        {{- $hostport := index .Ports "4444/TCP" -}}
-        {{- $parts := splitList ":" $hostport -}}
-        {{- $host := index $parts 0 -}}
-        {{- $port := "" -}}
-        {{- if gt (len $parts) 1 -}}
-          {{- $port = index $parts 1 -}}
-        {{- end -}}
-        nc {{ $host }} {{ $port }}

--- a/challenges/pwn/ret2popacola/infra/scenario/main.go
+++ b/challenges/pwn/ret2popacola/infra/scenario/main.go
@@ -101,6 +101,14 @@ func loadConfig(additionals map[string]string) (*Config, error) {
 	conf := &Config{
 		Hostname: "24hiut25.ctfer.io",
 		Image:    "pwn/ret2popacola:v0.1.0",
+		ConnectionInfo: `{{- $hostport := index .Ports "4444/TCP" -}}
+{{- $parts := splitList ":" $hostport -}}
+{{- $host := index $parts 0 -}}
+{{- $port := "" -}}
+{{- if gt (len $parts) 1 -}}
+	{{- $port = index $parts 1 -}}
+{{- end -}}
+nc {{ $host }} {{ $port }}`,
 	}
 
 	// Override with additionals


### PR DESCRIPTION
This PR removes the connection infos from additionals due to a bug in frontend handling of additionals in the [CTFd plugin](https://github.com/ctfer-io/ctfd-chall-manager).
Poke @NicoFgrx 